### PR TITLE
feat: 트랙 저장 및 불러오기

### DIFF
--- a/app/(drawer)/MyRunningPath.tsx
+++ b/app/(drawer)/MyRunningPath.tsx
@@ -1,3 +1,5 @@
+// 트랙 경로 불러오기
+
 import { deletePath, loadPaths, RunningTrack } from '@/storage/RunningStorage';
 import { useNavigation } from '@react-navigation/native';
 import React, { useEffect, useState } from 'react';

--- a/app/(drawer)/modeSelect.tsx
+++ b/app/(drawer)/modeSelect.tsx
@@ -13,14 +13,18 @@ export default function ModeSelect() {
       <View style={styles.container}>
         <Pressable
           style={styles.button}
-          onPress={() => router.push({ pathname: '/running', params: { mode: 'normal' } })}
+          onPress={() =>
+            router.push({ pathname: '/running', params: { mode: 'normal' } })
+          }
         >
           <Text style={styles.buttonText}>일반 모드</Text>
         </Pressable>
 
         <Pressable
           style={styles.button}
-          onPress={() => router.push({ pathname: '/trackSetup', params: { mode: 'track' } })}
+          onPress={() =>
+            router.push({ pathname: '/trackSetup', params: { mode: 'track' } })
+          }
         >
           <Text style={styles.buttonText}>트랙 모드</Text>
         </Pressable>
@@ -36,7 +40,7 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    justifyContent: 'center',   // 중앙 정렬
+    justifyContent: 'center', // 중앙 정렬
     alignItems: 'center',
     paddingHorizontal: 20,
   },

--- a/app/(drawer)/running-with-bot.tsx
+++ b/app/(drawer)/running-with-bot.tsx
@@ -1,4 +1,4 @@
-// 러닝 기능
+// 봇과 러닝 기능
 
 import { useRunning } from '@/context/RunningContext';
 import { useNavigation } from '@react-navigation/native';

--- a/app/(drawer)/running.tsx
+++ b/app/(drawer)/running.tsx
@@ -1,3 +1,5 @@
+// 러닝 기능
+
 import { useRunning } from '@/context/RunningContext';
 import { savePath } from '@/storage/RunningStorage';
 import * as Location from 'expo-location';

--- a/app/(drawer)/summary.tsx
+++ b/app/(drawer)/summary.tsx
@@ -1,3 +1,5 @@
+// 러닝 요약
+
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React from 'react';
 import { Dimensions, Pressable, StyleSheet, Text, View } from 'react-native';

--- a/app/(drawer)/trackSetup.tsx
+++ b/app/(drawer)/trackSetup.tsx
@@ -5,12 +5,12 @@ import { Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const DISTANCES = [
-    { label: '400 m', value: 0.4 },
-    { label: '1 km',   value: 1  },
-    { label: '3 km',   value: 3   },
-    { label: '5 km',   value: 5   },
-    { label: '10 km',  value: 10  },
-]; 
+  { label: '400 m', value: 0.4 },
+  { label: '1 km', value: 1 },
+  { label: '3 km', value: 3 },
+  { label: '5 km', value: 5 },
+  { label: '10 km', value: 10 },
+];
 
 export default function TrackSelect() {
   const router = useRouter();
@@ -27,7 +27,7 @@ export default function TrackSelect() {
     <SafeAreaView style={[styles.safeArea, { paddingTop: insets.top }]}>
       <View style={styles.container}>
         <Text style={styles.title}>트랙 거리 선택</Text>
-        {DISTANCES.map(({label, value}) => (
+        {DISTANCES.map(({ label, value }) => (
           <Pressable
             key={value}
             style={styles.button}
@@ -44,18 +44,27 @@ export default function TrackSelect() {
 const styles = StyleSheet.create({
   safeArea: { flex: 1, backgroundColor: '#fff' },
   container: {
-    flex: 1, justifyContent: 'center', alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
     paddingHorizontal: 20,
   },
   title: {
-    fontSize: 24, fontWeight: '700', marginBottom: 24,
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 24,
   },
   button: {
-    width: '100%', paddingVertical: 14, marginVertical: 6,
-    backgroundColor: '#28a745', borderRadius: 8,
+    width: '100%',
+    paddingVertical: 14,
+    marginVertical: 6,
+    backgroundColor: '#28a745',
+    borderRadius: 8,
     alignItems: 'center',
   },
   buttonText: {
-    color: '#fff', fontSize: 18, fontWeight: '600',
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '600',
   },
 });

--- a/components/CustomDrawer.tsx
+++ b/components/CustomDrawer.tsx
@@ -1,3 +1,5 @@
+// 햄버거 버튼
+
 import { useRouter } from 'expo-router'; // Href를 import 합니다.
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';

--- a/context/RunningContext.tsx
+++ b/context/RunningContext.tsx
@@ -1,4 +1,5 @@
 // context/RunningContext.tsx
+// addToPath 오류 수정
 
 import * as Location from 'expo-location';
 import React, {

--- a/storage/RunningStorage.ts
+++ b/storage/RunningStorage.ts
@@ -1,3 +1,5 @@
+// 트랙 경로 저장
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 const PATH_KEY = '@running_paths'; // 저장 Key
 


### PR DESCRIPTION
유저가 일반모드에서 달린 트랙을 저장 및 블러와 다양한 컨텐츠에 활용하기 위해 개발하였습니다. 만약 유저가 일반 모드에서 러닝을 시작하고 종료를 눌렀을 경우에, 트랙이 저장되었다는 알림과 함께 자동으로 저장됩니다. 이후 햄버거 창에서 나의 트랙을 확인하면 달린 경로를 그대로 확인할 수 있습니다. issue #4

## #️⃣연관된 이슈

> #4 

## 📝작업 내용

> 트랙을 저장하고 불러오는 기능을 추가하였습니다.

### 스크린샷 (선택)
<img width="603" alt="IMG_1911" src="https://github.com/user-attachments/assets/e91e6a79-3a0a-4cdb-9431-4f14e0310919" />
<img width="603" alt="IMG_1913" src="https://github.com/user-attachments/assets/006eaa62-f035-4558-ba48-6d492d859dd9" />