### PR TITLE
fix: 트랙 경로 이탈 후 복귀시 봇의 위치 버그 수정

### DIFF
--- a/hooks/useOffCourseDetection.ts
+++ b/hooks/useOffCourseDetection.ts
@@ -26,7 +26,7 @@ export const useOffCourseDetection = ({
   const offCourseRef = useRef(false);
 
   useEffect(() => {
-    if (!externalPath?.length || !userLocation || !isActive) return;
+    if (!externalPath?.length || !userLocation) return;
 
     // 코스 상의 모든 점과의 최소 거리 계산
     let minDistM = Infinity;
@@ -51,7 +51,7 @@ export const useOffCourseDetection = ({
       offCourseRef.current = false;
       onResume();
     }
-  }, [userLocation, externalPath, isActive, threshold, onPause, onResume, onOffCourse]);
+  }, [userLocation, externalPath,threshold, onPause, onResume, onOffCourse]);
 
   const resetOffCourse = useCallback(() => {
     offCourseRef.current = false;


### PR DESCRIPTION

## #️⃣연관된 이슈

> #104 

## 📝작업 내용

>  트랙 경로 이탈 후 복귀시 봇의 위치 버그 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
