### PR TITLE
[feature] 기록 상세에서 트랙모드이면 바로 트랙 상세페이지로 넘어가서 플레이할 수 있도록 하는 기능 추가

### DIFF
--- a/app/(drawer)/record/[recordId].tsx
+++ b/app/(drawer)/record/[recordId].tsx
@@ -11,9 +11,11 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View
 } from 'react-native';
 import MapView, { LatLng, Marker, Polyline } from 'react-native-maps';
+import type { SourceType } from '../TrackDetailScreen';
 
 interface RecordDetail {
   id: number;
@@ -260,6 +262,32 @@ export default function RecordDetailScreen() {
           <Text style={styles.value}>{calories} kcal</Text>
         </View>
       </View>
+      <View style={{ paddingHorizontal: 18, marginBottom: 24 }}>
+          <TouchableOpacity
+            style={{
+              backgroundColor: '#4a90e2',
+              padding: 12,
+              borderRadius: 8,
+              alignItems: 'center',
+            }}
+            onPress={() => {
+              const sourceParam: SourceType = detail.mode === 'FREE' ? 'my' : 'server';
+              router.push({
+                pathname: '/TrackDetailScreen',             // 실제 파일 경로로 조정
+                params: {
+                  trackId: detail.trackId.toString(),      // 문자열로 전달
+                  source: sourceParam,          // server 또는 my 중 선택
+                },
+              });
+            }}
+          >
+            <Text style={{ color: '#fff', fontWeight: '600' }}>
+              이 기록의 트랙 상세 보기
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+
     </ScrollView>
     </>
   );


### PR DESCRIPTION


## #️⃣연관된 이슈

>#111

## 📝작업 내용

>  기록 상세에서 트랙모드이면 바로 트랙 상세페이지로 넘어가서 플레이할 수 있도록 하는 기능 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
