### PR TITLE
fix:android 날씨 관련 json 안보임 문제 해결

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -51,7 +51,7 @@ export default function HomeScreen() {
       left: 0,
       right: 0,
       bottom: 0,
-      zIndex: 1,
+      zIndex: Platform.OS === 'android' ? 1:-1,
       pointerEvents: 'none',
     },
     snow: {
@@ -60,7 +60,7 @@ export default function HomeScreen() {
       left: 0,
       right: 0,
       bottom: 0,
-      zIndex: 1,
+      zIndex: Platform.OS === 'android' ? 1:-1,
       pointerEvents: 'none',
     },
     cloud: {
@@ -69,7 +69,7 @@ export default function HomeScreen() {
       right: 15,
       width: 130,
       height: 150,
-      zIndex: 1,
+      zIndex: Platform.OS === 'android' ? 1:-1,
       pointerEvents: 'none',
     },
     sunny: {
@@ -78,7 +78,7 @@ export default function HomeScreen() {
       left: 20,
       width: 120,
       height: 120,
-      zIndex: 1,
+      zIndex: Platform.OS === 'android' ? 1:-1,
       pointerEvents: 'none',
     },
     moon: {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,10 +3,10 @@ import CharacterSection from '@/components/CharacterSection';
 import { useDrawer } from '@/context/DrawerContext';
 import { useUserStore } from '@/stores/userStore';
 import {
-  getTimeBasedColors,
-  getWeatherAnimationKey,
-  getWeatherData,
-  WeatherAnimationKey,
+    getTimeBasedColors,
+    getWeatherAnimationKey,
+    getWeatherData,
+    WeatherAnimationKey,
 } from '@/utils/WeatherUtils';
 import { Entypo, FontAwesome5, Fontisto } from '@expo/vector-icons';
 import { useFonts } from 'expo-font';
@@ -17,14 +17,15 @@ import * as SplashScreen from 'expo-splash-screen';
 import LottieView from 'lottie-react-native';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  Alert,
-  Modal,
-  Pressable,
-  SafeAreaView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View
+    Alert,
+    Modal,
+    Pressable,
+    SafeAreaView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+    Platform
 } from 'react-native';
 
 const SERVER_API_URL = process.env.EXPO_PUBLIC_SERVER_API_URL;
@@ -50,7 +51,7 @@ export default function HomeScreen() {
       left: 0,
       right: 0,
       bottom: 0,
-      zIndex: -1,
+      zIndex: 1,
       pointerEvents: 'none',
     },
     snow: {
@@ -59,7 +60,7 @@ export default function HomeScreen() {
       left: 0,
       right: 0,
       bottom: 0,
-      zIndex: -1,
+      zIndex: 1,
       pointerEvents: 'none',
     },
     cloud: {
@@ -68,7 +69,7 @@ export default function HomeScreen() {
       right: 15,
       width: 130,
       height: 150,
-      zIndex: -1,
+      zIndex: 1,
       pointerEvents: 'none',
     },
     sunny: {
@@ -77,7 +78,7 @@ export default function HomeScreen() {
       left: 20,
       width: 120,
       height: 120,
-      zIndex: -1,
+      zIndex: 1,
       pointerEvents: 'none',
     },
     moon: {
@@ -86,7 +87,7 @@ export default function HomeScreen() {
       left: 10,
       width: 140,
       height: 140,
-      zIndex: -1,
+      zIndex: Platform.OS === 'android' ? 1:-1,
       pointerEvents: 'none',
     },
   };


### PR DESCRIPTION
## #️⃣연관된 이슈

>#226

## 📝작업 내용

android에서는 zIndex를 1이상으로 해야 함. 그렇지 않으면 아예 View가 렌더링되지 않거나, 부모 View의 구조에 따라 완전히 사라지는 현상이 자주 발생함.
zIndex를 1로 수정하니 ios에서는 반대로 날씨 관련 .json이 아바타 앞에 오는 상황 발생.
-> Platform.OS로 ios에서는 -1, android에서는 1이 되도록 분기함.


